### PR TITLE
Retrieve account base by imgur id

### DIFF
--- a/src/main/java/com/github/kskelm/baringo/AccountService.java
+++ b/src/main/java/com/github/kskelm/baringo/AccountService.java
@@ -57,6 +57,29 @@ public class AccountService {
 
 
 	/**
+	 * Given an account id, return the Account object for it.
+	 * @param userId The user-id of the account.
+	 * @return Account object
+	 */
+	public Account getAccount( long userId ) throws BaringoApiException
+	{
+		Call<ImgurResponseWrapper<Account>> call =
+				client.getApi().getAccount( userId );
+
+		try {
+			Response<ImgurResponseWrapper<Account>> res = call.execute();
+			ImgurResponseWrapper<Account> out = res.body();
+			client.throwOnWrapperError( res );
+
+			return out.getData();
+		} catch (IOException e) {
+			throw new BaringoApiException( e.getMessage() );
+		}
+	} // getAccount
+
+
+
+	/**
 	 * Given an account name and a page number (starting at 0),
 	 * return a list of GalleryItems that user has favorited.
 	 * GalleryItem is the superclass for GalleryImage and

--- a/src/main/java/com/github/kskelm/baringo/util/RetrofittedImgur.java
+++ b/src/main/java/com/github/kskelm/baringo/util/RetrofittedImgur.java
@@ -68,6 +68,10 @@ public interface RetrofittedImgur {
 	Call<ImgurResponseWrapper<Account>> getAccount(
 			@Path("username") String userName );
 
+	@GET("/3/account")
+	Call<ImgurResponseWrapper<Account>> getAccount(
+			@Query("account_id") long accountId );
+
 	@GET("/3/account/{username}/gallery_favorites/{page}/{sort}")
 	Call<ImgurResponseWrapper<List<GalleryItemProxy>>> listAccountGalleryFavorites(
 			@Path("username") String userName,

--- a/src/test/java/com/github/kskelm/baringo/test/AccountTest.java
+++ b/src/test/java/com/github/kskelm/baringo/test/AccountTest.java
@@ -32,7 +32,22 @@ public class AccountTest extends TestCase {
 
 		assertEquals( "Bio is set", acct.getBio(), "Test profile" );
 		assertEquals( "Account id is set", acct.getId(), 33527752 );
-		assertEquals( "Created is set", acct.getCreated().getTime(), 1459093737000L );	
+		assertEquals( "Created is set", acct.getCreated().getTime(), 1459093737000L );
+
+
+
+	}
+
+	@Test
+	public void testGetAccountWithId() throws BaringoApiException
+	{
+		Setup setup = new Setup();
+
+		Account acct = setup.getClient().accountService().getAccount( 33527752 );
+
+		assertEquals( "Bio is set", acct.getBio(), "Test profile" );
+		assertEquals( "Account id is set", acct.getUserName(), Setup.TEST_USER_NAME );
+		assertEquals( "Created is set", acct.getCreated().getTime(), 1459093737000L );
 	}
 
 	@Test


### PR DESCRIPTION
The Imgur API allows for the account base to be retrieved with a known imgur id (https://apidocs.imgur.com/#c94c8719-fe68-4854-b96d-70735dd8b2bc).

Hello there, 

Every now and then users on imgur will change their names. When they do, their account id does not change. As such, in order to keep track of certain users it is important for me to be able to retrieve their new account name should the old one return a 404. 